### PR TITLE
Update the return type of MPU6050::getMotionStatus()

### DIFF
--- a/Arduino/MPU6050/MPU6050.cpp
+++ b/Arduino/MPU6050/MPU6050.cpp
@@ -1994,7 +1994,7 @@ uint32_t MPU6050::getExternalSensorDWord(int position) {
  * @return Motion detection status byte
  * @see MPU6050_RA_MOT_DETECT_STATUS
  */
-bool MPU6050::getMotionStatus() {
+uint8_t MPU6050::getMotionStatus() {
     I2Cdev::readByte(devAddr, MPU6050_RA_MOT_DETECT_STATUS, buffer);
     return buffer[0];
 }


### PR DESCRIPTION
The return type of MPU6050::getMotionStatus() in MPU6050.h is uint8_t.
